### PR TITLE
removing pipes around help csapprox-changelog for user

### DIFF
--- a/plugin/CSApprox.vim
+++ b/plugin/CSApprox.vim
@@ -1,4 +1,4 @@
-" CSApprox:    Make gvim-only colorschemes Just Work terminal vim
+/" CSApprox:    Make gvim-only colorschemes Just Work terminal vim
 " Maintainer:  Matthew Wozniski (godlygeek@gmail.com)
 " Date:        Fri, 14 Sep 2012 01:12:13 -0400
 " Version:     4.00
@@ -61,7 +61,7 @@ elseif !has('gui') && v:version < 703
   " Warn unless the user set g:CSApprox_verbose_level to zero.
   if get(g:, 'CSApprox_verbose_level', 1)
     echomsg "CSApprox needs gui support - not loading."
-    echomsg "  See :help |csapprox-+gui| for possible workarounds."
+    echomsg "  See :help csapprox-+gui for possible workarounds."
   endif
 
   finish


### PR DESCRIPTION
An error message for users "See :help |csapprox-+gui| for possible workarounds." needed pipes removed
