### PR TITLE
Suppress warning message with GVim, because it has enough colors.

### DIFF
--- a/plugin/CSApprox.vim
+++ b/plugin/CSApprox.vim
@@ -561,7 +561,7 @@ endfunction
 function! s:CSApproxImpl()
   " Return if not running in an 88/256 color terminal
   if &t_Co != 256 && &t_Co != 88
-    if &verbose && &t_Co != ''
+    if &verbose && &t_Co != '' && &t_Co < 256
       echomsg "CSApprox skipped; terminal only has" &t_Co "colors, not 88/256"
       echomsg "Try checking :help csapprox-terminal for workarounds"
     endif


### PR DESCRIPTION
Proposed fix for Issue #17 .